### PR TITLE
fix: getFilteredFields function

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -189,6 +189,8 @@ func getFilteredFields(fields []fieldInfo, removeFieldsIndexes []int) []fieldInf
 				newFields = append(newFields, field)
 			}
 		}
+	} else {
+		newFields = fields
 	}
 	return newFields
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -146,7 +146,7 @@ func Test_writeTo_slice(t *testing.T) {
 		},
 	}
 
-	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false); err != nil {
+	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false, []int{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -315,7 +315,7 @@ func Test_writeTo_embedmarshalCSV(t *testing.T) {
 	}
 
 	// Next, attempt to write our test data to a CSV format
-	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false); err != nil {
+	if err := writeTo(NewSafeCSVWriter(csv.NewWriter(e.out)), s, false, []int{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -448,7 +448,7 @@ func Test_MarshalChan_ClosedChannel(t *testing.T) {
 	c := make(chan interface{})
 	close(c)
 
-	if err := MarshalChan(c, NewSafeCSVWriter(csv.NewWriter(e.out))); !errors.Is(err, ErrChannelIsClosed) {
+	if err := MarshalChan(c, NewSafeCSVWriter(csv.NewWriter(e.out)), []int{}); !errors.Is(err, ErrChannelIsClosed) {
 		t.Fatal(err)
 	}
 }

--- a/unmarshaller_test.go
+++ b/unmarshaller_test.go
@@ -69,7 +69,7 @@ func TestUnmarshalListOfStructsAfterMarshal(t *testing.T) {
 	innerWriter := csv.NewWriter(buffer)
 	innerWriter.Comma = '|'
 	csvWriter := NewSafeCSVWriter(innerWriter)
-	if err := MarshalCSV(inData, csvWriter); err != nil {
+	if err := MarshalCSV(inData, csvWriter, []int{}); err != nil {
 		t.Fatalf("Error marshalling data to CSV: %#v", err)
 	}
 


### PR DESCRIPTION
If empty slice is passed to removeFieldsIndexes, the ```getFilteredFields```function passed empty slice.
Corrected to return the data in the corresponding column as it is.