### PR TITLE
fix:  Delete local cache at the end of function

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -33,8 +33,7 @@ func writeFromChan(writer CSVWriter, c <-chan interface{}, omitHeaders bool, rem
 		return err
 	}
 	inInnerWasPointer := inType.Kind() == reflect.Ptr
-	inInnerStructInfo := getStructInfo(inType)                                                  // Get the inner struct info to get CSV annotations
-	defer structInfoCache.Delete(inType)                                                        // Delete local cache at the end of function
+	inInnerStructInfo := getStructInfoNoCache(inType)                                           // Get the inner struct info to get CSV annotations
 	inInnerStructInfo.Fields = getFilteredFields(inInnerStructInfo.Fields, removeFieldsIndexes) // Filtered out ignoreFields from all fields
 	csvHeadersLabels := make([]string, len(inInnerStructInfo.Fields))
 	for i, fieldInfo := range inInnerStructInfo.Fields { // Used to write the header (first line) in CSV
@@ -86,9 +85,8 @@ func writeTo(writer CSVWriter, in interface{}, omitHeaders bool, removeFieldsInd
 	if err := ensureInInnerType(inInnerType); err != nil {
 		return err
 	}
-	inInnerStructInfo := getStructInfo(inInnerType) // Get the inner struct info to get CSV annotations
-	defer structInfoCache.Delete(inInnerType)       // Delete local cache at the end of function
 
+	inInnerStructInfo := getStructInfoNoCache(inInnerType)                                      // Get the inner struct info to get CSV annotations
 	inInnerStructInfo.Fields = getFilteredFields(inInnerStructInfo.Fields, removeFieldsIndexes) // Filtered out ignoreFields from all fields
 
 	csvHeadersLabels := make([]string, len(inInnerStructInfo.Fields))

--- a/encode.go
+++ b/encode.go
@@ -34,6 +34,7 @@ func writeFromChan(writer CSVWriter, c <-chan interface{}, omitHeaders bool, rem
 	}
 	inInnerWasPointer := inType.Kind() == reflect.Ptr
 	inInnerStructInfo := getStructInfo(inType)                                                  // Get the inner struct info to get CSV annotations
+	defer structInfoCache.Delete(inType)                                                        // Delete local cache at the end of function
 	inInnerStructInfo.Fields = getFilteredFields(inInnerStructInfo.Fields, removeFieldsIndexes) // Filtered out ignoreFields from all fields
 	csvHeadersLabels := make([]string, len(inInnerStructInfo.Fields))
 	for i, fieldInfo := range inInnerStructInfo.Fields { // Used to write the header (first line) in CSV
@@ -86,6 +87,7 @@ func writeTo(writer CSVWriter, in interface{}, omitHeaders bool, removeFieldsInd
 		return err
 	}
 	inInnerStructInfo := getStructInfo(inInnerType) // Get the inner struct info to get CSV annotations
+	defer structInfoCache.Delete(inInnerType)       // Delete local cache at the end of function
 
 	inInnerStructInfo.Fields = getFilteredFields(inInnerStructInfo.Fields, removeFieldsIndexes) // Filtered out ignoreFields from all fields
 

--- a/reflect.go
+++ b/reflect.go
@@ -42,6 +42,11 @@ var structInfoCache sync.Map
 var structMap = make(map[reflect.Type]*structInfo)
 var structMapMutex sync.RWMutex
 
+func getStructInfoNoCache(rType reflect.Type) *structInfo {
+	fieldsList := getFieldInfos(rType, []int{}, []string{})
+	return &structInfo{fieldsList}
+}
+
 func getStructInfo(rType reflect.Type) *structInfo {
 	stInfo, ok := structInfoCache.Load(rType)
 	if ok {


### PR DESCRIPTION
Caches are now deleted for each process to accommodate dynamic column reordering and column removal functions.